### PR TITLE
added support for optional running of one ets table per module.

### DIFF
--- a/lib/memoize/application.ex
+++ b/lib/memoize/application.ex
@@ -17,7 +17,7 @@ defmodule Memoize.Application do
   def init(_opts) do
     caches = Application.get_env(:memoize, :caches)
     @cache_strategy.init(caches: caches)
-    Supervisor.Spec.supervise([], strategy: :one_for_one)
+    Supervisor.init([], strategy: :one_for_one)
   end
 
   def cache_strategy() do

--- a/lib/memoize/application.ex
+++ b/lib/memoize/application.ex
@@ -7,15 +7,16 @@ defmodule Memoize.Application do
   @cache_strategy Application.get_env(:memoize, :cache_strategy, Memoize.CacheStrategy.Default)
 
   def start(_type, _args) do
-    Supervisor.start_link(__MODULE__, [], strategy: :one_for_one)
+    Supervisor.start_link(__MODULE__, [], strategy: :one_for_one, name: __MODULE__)
   end
 
   def stop(_state) do
     :ok
   end
 
-  def init(_) do
-    @cache_strategy.init()
+  def init(_opts) do
+    caches = Application.get_env(:memoize, :caches)
+    @cache_strategy.init(caches: caches)
     Supervisor.Spec.supervise([], strategy: :one_for_one)
   end
 

--- a/lib/memoize/cache.ex
+++ b/lib/memoize/cache.ex
@@ -180,6 +180,7 @@ defmodule Memoize.Cache do
               {^runner_pid, :failed} -> :ok
               {:DOWN, ^ref, :process, ^runner_pid, _reason} -> :ok
             after
+              # todo: make this configurable
               5000 -> :ok
             end
 

--- a/lib/memoize/cache_strategy.ex
+++ b/lib/memoize/cache_strategy.ex
@@ -1,11 +1,14 @@
 defmodule Memoize.CacheStrategy do
-  @callback init() :: any
-  @callback tab(any) :: atom
-  @callback cache(any, any, Keyword.t()) :: any
-  @callback read(any, any, any) :: :ok | :retry
+  @callback init(Keyword.t()) :: any
+  @callback tab(atom, any) :: atom
+  @callback cache(atom, any, any, Keyword.t()) :: any
+  @callback read(atom, any, any, any) :: :ok | :retry
   @callback invalidate() :: integer
-  @callback invalidate(any) :: integer
+  @callback invalidate(atom) :: integer
+  @callback invalidate(atom, atom) :: integer
+  @callback invalidate(atom, atom, any) :: integer
   @callback garbage_collect() :: integer
+  @callback garbage_collect(atom) :: integer
 
   def configured?(mod) do
     Application.get_env(:memoize, :cache_strategy, Memoize.CacheStrategy.Default) == mod

--- a/lib/memoize/cache_strategy/default.ex
+++ b/lib/memoize/cache_strategy/default.ex
@@ -4,18 +4,35 @@ if Memoize.CacheStrategy.configured?(Memoize.CacheStrategy.Default) do
 
     @behaviour Memoize.CacheStrategy
 
-    @ets_tab __MODULE__
+    @default_expires_in Application.get_env(:memoize, :expires_in, :infinity)
 
-    def init() do
-      :ets.new(@ets_tab, [:public, :set, :named_table, {:read_concurrency, true}])
+    @ets_tab __MODULE__
+    alias Memoize.Cache
+
+    def init(opts) do
+      case Keyword.get(opts, :caches) do
+        nil ->
+          :ets.new(tab(nil), [:public, :set, :named_table, {:read_concurrency, true}])
+
+        caches ->
+          Enum.each(caches, fn cache ->
+            :ets.new(tab(cache), [:public, :set, :named_table, {:read_concurrency, true}])
+          end)
+      end
     end
 
-    def tab(_key) do
+    def tab(_module, _key \\ nil)
+
+    def tab(nil, _key) do
       @ets_tab
     end
 
-    def cache(_key, _value, opts) do
-      expires_in = Keyword.get(opts, :expires_in, :infinity)
+    def tab(module, _key) do
+      Module.concat(@ets_tab, module)
+    end
+
+    def cache(_module, _key, _value, opts) do
+      expires_in = Keyword.get(opts, :expires_in, @default_expires_in)
 
       expired_at =
         case expires_in do
@@ -26,30 +43,118 @@ if Memoize.CacheStrategy.configured?(Memoize.CacheStrategy.Default) do
       expired_at
     end
 
-    def read(key, _value, expired_at) do
+    def read(cache_name, key, _value, expired_at) do
       if expired_at != :infinity && System.monotonic_time(:millisecond) > expired_at do
-        invalidate(key)
+        local_invalidate(cache_name, key)
         :retry
       else
         :ok
       end
     end
 
-    def invalidate() do
-      :ets.select_delete(@ets_tab, [{{:_, {:completed, :_, :_}}, [], [true]}])
+    defp local_invalidate(cache_name, key) do
+      :ets.select_delete(tab(cache_name), [{{key, {:completed, :_, :_}}, [], [true]}])
     end
 
-    def invalidate(key) do
-      :ets.select_delete(@ets_tab, [{{key, {:completed, :_, :_}}, [], [true]}])
+    def invalidate() do
+      # this is only place we have to run get_env, but given we are deleting everything its fine.
+      case Application.get_env(:memoize, :caches) do
+        nil ->
+          :ets.select_delete(tab(nil), [{{:_, {:completed, :_, :_}}, [], [true]}])
+
+        modules ->
+          Enum.reduce(modules, 0, fn module, acc ->
+            :ets.select_delete(tab(module), [{{:_, {:completed, :_, :_}}, [], [true]}]) + acc
+          end)
+      end
+    end
+
+    def invalidate(module) do
+      cache_name = Cache.cache_name(module)
+
+      cache_name
+      |> tab()
+      |> :ets.select_delete([{{key(cache_name, module), {:completed, :_, :_}}, [], [true]}])
+    end
+
+    def invalidate(module, function) do
+      cache_name = Cache.cache_name(module)
+
+      cache_name
+      |> tab()
+      |> :ets.select_delete([
+        {{key(cache_name, module, function), {:completed, :_, :_}}, [], [true]}
+      ])
+    end
+
+    def invalidate(module, function, args) do
+      cache_name = Cache.cache_name(module)
+
+      cache_name
+      |> tab()
+      |> :ets.select_delete([
+        {{key(cache_name, module, function, args), {:completed, :_, :_}}, [], [true]}
+      ])
     end
 
     def garbage_collect() do
       expired_at = System.monotonic_time(:millisecond)
+      # this is only place we have to run get_env, but given we are deleting everything its fine.
+      case Application.get_env(:memoize, :caches) do
+        nil ->
+          :ets.select_delete(tab(nil), [
+            {{:_, {:completed, :_, :"$1"}},
+             [{:andalso, {:"/=", :"$1", :infinity}, {:<, :"$1", {:const, expired_at}}}], [true]}
+          ])
 
-      :ets.select_delete(@ets_tab, [
-        {{:_, {:completed, :_, :"$1"}},
+        modules ->
+          Enum.reduce(modules, 0, fn module, acc ->
+            :ets.select_delete(tab(module), [
+              {{:_, {:completed, :_, :"$1"}},
+               [{:andalso, {:"/=", :"$1", :infinity}, {:<, :"$1", {:const, expired_at}}}], [true]}
+            ]) + acc
+          end)
+      end
+    end
+
+    def garbage_collect(module) do
+      expired_at = System.monotonic_time(:millisecond)
+
+      cache_name = Cache.cache_name(module)
+
+      cache_name
+      |> tab()
+      |> :ets.select_delete([
+        {{key(cache_name, module), {:completed, :_, :"$1"}},
          [{:andalso, {:"/=", :"$1", :infinity}, {:<, :"$1", {:const, expired_at}}}], [true]}
       ])
+    end
+
+    # ets per module
+    defp key(module_name, module_name) do
+      {:_, :_}
+    end
+
+    defp key(_cache_name, module_name) do
+      {module_name, :_, :_}
+    end
+
+    # ets per module
+    defp key(module_name, module_name, function_name) do
+      {function_name, :_}
+    end
+
+    defp key(_cache_name, module_name, function_name) do
+      {module_name, function_name, :_}
+    end
+
+    # ets per module
+    defp key(module_name, module_name, function_name, args) do
+      {function_name, args}
+    end
+
+    defp key(_cache_name, module_name, function_name, args) do
+      {module_name, function_name, args}
     end
   end
 end

--- a/lib/memoize/cache_strategy/eviction.ex
+++ b/lib/memoize/cache_strategy/eviction.ex
@@ -12,44 +12,70 @@ if Memoize.CacheStrategy.configured?(Memoize.CacheStrategy.Eviction) do
       @min_threshold Keyword.fetch!(@opts, :min_threshold)
     end
 
-    def init() do
-      :ets.new(@ets_tab, [:public, :set, :named_table, {:read_concurrency, true}])
-      :ets.new(@read_history_tab, [:public, :set, :named_table, {:write_concurrency, true}])
-      :ets.new(@expiration_tab, [:public, :ordered_set, :named_table])
+    def init(opts) do
+      case Keyword.get(opts, :caches) do
+        nil ->
+          :ets.new(tab(nil), [:public, :set, :named_table, {:read_concurrency, true}])
+          :ets.new(history_tab(nil), [:public, :set, :named_table, {:write_concurrency, true}])
+          :ets.new(expiration_tab(nil), [:public, :ordered_set, :named_table])
+
+        caches ->
+          Enum.each(caches, fn cache ->
+            :ets.new(tab(cache), [:public, :set, :named_table, {:read_concurrency, true}])
+
+            :ets.new(history_tab(cache), [:public, :set, :named_table, {:write_concurrency, true}])
+
+            :ets.new(expiration_tab(cache), [:public, :ordered_set, :named_table])
+          end)
+      end
     end
 
-    def tab(_key) do
+    defp history_tab(cache) do
+      Module.concat(tab(cache), ReadHistory)
+    end
+
+    defp expiration_tab(cache) do
+      Module.concat(tab(cache), Expiration)
+    end
+
+    def tab(_module, _key \\ nil)
+
+    def tab(nil, _key) do
       @ets_tab
     end
 
-    def used_bytes() do
+    def tab(module, _key) do
+      Module.concat(@ets_tab, module)
+    end
+
+    def used_bytes(cache) do
       words = 0
-      words = words + :ets.info(@ets_tab, :memory)
-      words = words + :ets.info(@read_history_tab, :memory)
+      words = words + :ets.info(tab(cache), :memory)
+      words = words + :ets.info(history_tab(cache), :memory)
 
       words * :erlang.system_info(:wordsize)
     end
 
     if @max_threshold == :infinity do
-      def cache(key, value, opts) do
-        do_cache(key, value, opts)
+      def cache(cache, key, value, opts) do
+        do_cache(cache, key, value, opts)
       end
     else
-      def cache(key, value, opts) do
-        if used_bytes() > @max_threshold do
-          garbage_collect()
+      def cache(cache, key, value, opts) do
+        if used_bytes(cache) > @max_threshold do
+          garbage_collect(cache)
         end
 
-        do_cache(key, value, opts)
+        do_cache(cache, key, value, opts)
       end
     end
 
-    defp do_cache(key, _value, opts) do
+    defp do_cache(cache, key, _value, opts) do
       case Keyword.fetch(opts, :expires_in) do
         {:ok, expires_in} ->
           expired_at = System.monotonic_time(:millisecond) + expires_in
           counter = System.unique_integer()
-          :ets.insert(@expiration_tab, {{expired_at, counter}, key})
+          :ets.insert(expiration_tab(cache), {{expired_at, counter}, key})
 
         :error ->
           :ok
@@ -58,88 +84,217 @@ if Memoize.CacheStrategy.configured?(Memoize.CacheStrategy.Eviction) do
       %{permanent: Keyword.get(opts, :permanent, false)}
     end
 
-    def read(key, _value, context) do
-      expired? = clear_expired_cache(key)
+    def read(cache, key, _value, context) do
+      expired? = clear_expired_cache(cache, key)
 
       unless context.permanent do
         counter = System.unique_integer([:monotonic, :positive])
-        :ets.insert(@read_history_tab, {key, counter})
+        :ets.insert(history_tab(cache), {key, counter})
       end
 
       if expired?, do: :retry, else: :ok
     end
 
     def invalidate() do
-      num_deleted = :ets.select_delete(@ets_tab, [{{:_, {:completed, :_, :_}}, [], [true]}])
-      :ets.delete_all_objects(@read_history_tab)
-      num_deleted
-    end
+      case Application.get_env(:memoize, :caches) do
+        nil ->
+          num_deleted = :ets.select_delete(tab(nil), [{{:_, {:completed, :_, :_}}, [], [true]}])
+          :ets.delete_all_objects(history_tab(nil))
+          num_deleted
 
-    def invalidate(key) do
-      num_deleted = :ets.select_delete(@ets_tab, [{{key, {:completed, :_, :_}}, [], [true]}])
-      :ets.select_delete(@read_history_tab, [{{key, :_}, [], [true]}])
-      num_deleted
-    end
+        modules ->
+          Enum.reduce(modules, 0, fn module, acc ->
+            num_deleted =
+              :ets.select_delete(tab(module), [{{:_, {:completed, :_, :_}}, [], [true]}]) + acc
 
-    if @max_threshold == :infinity do
-      def garbage_collect() do
-        # never don't collect
-        0
+            :ets.delete_all_objects(history_tab(module))
+            num_deleted
+          end)
       end
-    else
-      def garbage_collect() do
-        if used_bytes() <= @min_threshold do
-          # still don't collect
-          0
-        else
-          # remove values ordered by last accessed time until used bytes less than @min_threshold.
-          values = :lists.keysort(2, :ets.tab2list(@read_history_tab))
-          stream = values |> Stream.filter(fn n -> n != :permanent end) |> Stream.with_index(1)
+    end
 
-          try do
-            for {{key, _}, num_deleted} <- stream do
-              :ets.select_delete(@ets_tab, [{{key, {:completed, :_, :_}}, [], [true]}])
-              :ets.delete(@read_history_tab, key)
+    def invalidate(module) do
+      cache_name = Cache.cache_name(module)
 
-              if used_bytes() <= @min_threshold do
-                throw({:break, num_deleted})
-              end
+      num_deleted =
+        cache_name
+        |> tab()
+        |> :ets.select_delete([{{key(cache_name, module), {:completed, :_, :_}}, [], [true]}])
+
+      :ets.select_delete(history_tab(cache_name), [{key(cache_name, module), [], [true]}])
+      num_deleted
+    end
+
+    def invalidate(module, function) do
+      cache_name = Cache.cache_name(module)
+
+      num_deleted =
+        cache_name
+        |> tab()
+        |> :ets.select_delete([
+          {{key(cache_name, module, function), {:completed, :_, :_}}, [], [true]}
+        ])
+
+      :ets.select_delete(history_tab(cache_name), [
+        {key(cache_name, module, function), [], [true]}
+      ])
+
+      num_deleted
+    end
+
+    def invalidate(module, function, args) do
+      cache_name = Cache.cache_name(module)
+
+      num_deleted =
+        cache_name
+        |> tab()
+        |> :ets.select_delete([
+          {{key(cache_name, module, function, args), {:completed, :_, :_}}, [], [true]}
+        ])
+
+      :ets.select_delete(history_tab(cache_name), [
+        {key(cache_name, module, function, args), [], [true]}
+      ])
+
+      num_deleted
+    end
+
+    def garbage_collect() do
+      do_garbage_collect_all(@max_threshold)
+    end
+
+    def garbage_collect(module) do
+      do_garbage_collect(@max_threshold, module)
+    end
+
+    def do_garbage_collect(:infinity, _) do
+      0
+    end
+
+    def do_garbage_collect(_, module) do
+      cache = Cache.cache_name(module)
+
+      if used_bytes(cache) <= @min_threshold do
+        # still don't collect
+        0
+      else
+        # remove values ordered by last accessed time until used bytes less than @min_threshold.
+        values = :lists.keysort(2, :ets.tab2list(history_tab(cache)))
+        stream = values |> Stream.filter(fn n -> n != :permanent end) |> Stream.with_index(1)
+
+        try do
+          for {{key, _}, num_deleted} <- stream do
+            case is_our_key?(key, module) do
+              true ->
+                :ets.select_delete(tab(cache), [{{key, {:completed, :_, :_}}, [], [true]}])
+                :ets.delete(history_tab(cache), key)
+
+              false ->
+                0
             end
-          else
-            _ -> length(values)
-          catch
-            {:break, num_deleted} -> num_deleted
+
+            if used_bytes(cache) <= @min_threshold do
+              throw({:break, num_deleted})
+            end
           end
+        else
+          _ -> length(values)
+        catch
+          {:break, num_deleted} -> num_deleted
         end
       end
     end
 
-    def clear_expired_cache(read_key \\ nil, expired? \\ false) do
-      case :ets.first(@expiration_tab) do
+    defp is_our_key?({_, _}, _), do: true
+    defp is_our_key?({module, _, _}, module), do: true
+    defp is_our_key?(_, _), do: false
+
+    def do_garbage_collect_all(:infinity) do
+      0
+    end
+
+    def do_garbage_collect_all(_) do
+      Application.get_env(:memoize, :caches, [nil])
+      |> Enum.reduce(0, fn cache, acc ->
+        if used_bytes(cache) <= @min_threshold do
+          # still don't collect
+          0 + acc
+        else
+          # remove values ordered by last accessed time until used bytes less than @min_threshold.
+          values = :lists.keysort(2, :ets.tab2list(history_tab(cache)))
+          stream = values |> Stream.filter(fn n -> n != :permanent end) |> Stream.with_index(1)
+
+          try do
+            for {{key, _}, num_deleted} <- stream do
+              :ets.select_delete(tab(cache), [{{key, {:completed, :_, :_}}, [], [true]}])
+              :ets.delete(history_tab(cache), key)
+
+              if used_bytes(cache) <= @min_threshold do
+                throw({:break, num_deleted})
+              end
+            end
+          else
+            _ -> length(values) + acc
+          catch
+            {:break, num_deleted} -> num_deleted + acc
+          end
+        end
+      end)
+    end
+
+    def clear_expired_cache(cache, read_key \\ nil, expired? \\ false) do
+      case :ets.first(expiration_tab(cache)) do
         :"$end_of_table" ->
           expired?
 
         {expired_at, _counter} = key ->
-          case :ets.lookup(@expiration_tab, key) do
+          case :ets.lookup(expiration_tab(cache), key) do
             [] ->
               # retry
-              clear_expired_cache(read_key, expired?)
+              clear_expired_cache(cache, read_key, expired?)
 
             [{^key, cache_key}] ->
               now = System.monotonic_time(:millisecond)
 
               if now > expired_at do
                 invalidate(cache_key)
-                :ets.delete(@expiration_tab, key)
+                :ets.delete(expiration_tab(cache), key)
                 expired? = expired? || cache_key == read_key
                 # next
-                clear_expired_cache(read_key, expired?)
+                clear_expired_cache(cache, read_key, expired?)
               else
                 # completed
                 expired?
               end
           end
       end
+    end
+
+    # ets per module
+    defp key(module_name, module_name) do
+      {:_, :_}
+    end
+
+    defp key(_cache_name, module_name) do
+      {module_name, :_, :_}
+    end
+
+    # ets per module
+    defp key(module_name, module_name, function_name) do
+      {function_name, :_}
+    end
+
+    defp key(_cache_name, module_name, function_name) do
+      {module_name, function_name, :_}
+    end
+
+    # ets per module
+    defp key(module_name, module_name, function_name, args) do
+      {function_name, args}
+    end
+
+    defp key(_cache_name, module_name, function_name, args) do
+      {module_name, function_name, args}
     end
   end
 end

--- a/lib/memoize/cache_strategy/simple.ex
+++ b/lib/memoize/cache_strategy/simple.ex
@@ -1,0 +1,78 @@
+if Memoize.CacheStrategy.configured?(Memoize.CacheStrategy.Simple) do
+  defmodule Memoize.CacheStrategy.Simple do
+    @moduledoc false
+
+    @behaviour Memoize.CacheStrategy
+
+    @ets_tab __MODULE__
+
+    def init(_) do
+      :ets.new(@ets_tab, [:public, :set, :named_table, {:read_concurrency, true}])
+    end
+
+    def tab(_module, _key \\ nil) do
+      @ets_tab
+    end
+
+    def cache(_module, _key, _value, opts) do
+      expires_in = Keyword.get(opts, :expires_in, :infinity)
+
+      expired_at =
+        case expires_in do
+          :infinity -> :infinity
+          value -> System.monotonic_time(:millisecond) + value
+        end
+
+      expired_at
+    end
+
+    def read(_module, key, _value, expired_at) do
+      if expired_at != :infinity && System.monotonic_time(:millisecond) > expired_at do
+        local_invalidate(key)
+        :retry
+      else
+        :ok
+      end
+    end
+
+    defp local_invalidate(key) do
+      :ets.select_delete(@ets_tab, [{{key, {:completed, :_, :_}}, [], [true]}])
+    end
+
+    def invalidate() do
+      :ets.select_delete(@ets_tab, [{{:_, {:completed, :_, :_}}, [], [true]}])
+    end
+
+    def invalidate(module) do
+      :ets.select_delete(@ets_tab, [{{{module, :_, :_}, {:completed, :_, :_}}, [], [true]}])
+    end
+
+    def invalidate(module, function) do
+      :ets.select_delete(@ets_tab, [{{{module, function, :_}, {:completed, :_, :_}}, [], [true]}])
+    end
+
+    def invalidate(module, function, args) do
+      :ets.select_delete(@ets_tab, [
+        {{{module, function, args}, {:completed, :_, :_}}, [], [true]}
+      ])
+    end
+
+    def garbage_collect() do
+      expired_at = System.monotonic_time(:millisecond)
+
+      :ets.select_delete(@ets_tab, [
+        {{:_, {:completed, :_, :"$1"}},
+         [{:andalso, {:"/=", :"$1", :infinity}, {:<, :"$1", {:const, expired_at}}}], [true]}
+      ])
+    end
+
+    def garbage_collect(module) do
+      expired_at = System.monotonic_time(:millisecond)
+
+      :ets.select_delete(@ets_tab, [
+        {{{module, :_, :_}, {:completed, :_, :"$1"}},
+         [{:andalso, {:"/=", :"$1", :infinity}, {:<, :"$1", {:const, expired_at}}}], [true]}
+      ])
+    end
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm", "b42a23e9bd92d65d16db2f75553982e58519054095356a418bb8320bbacb58b1"},
+  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "dc87f778d8260da0189a622f62790f6202af72f2f3dee6e78d91a18dd2fcd137"},
+  "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "d7152ff93f2eac07905f510dfa03397134345ba4673a00fbf7119bab98632940"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "4a36dd2d0d5c5f98d95b3f410d7071cd661d5af310472229dd0e92161f168a44"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm", "ebb595e19456a72786db6dcd370d320350cb624f0b6203fcc7e23161d49b0ffb"},
 }

--- a/test/memoize_test.exs
+++ b/test/memoize_test.exs
@@ -3,6 +3,8 @@ defmodule MemoizeTest do
 
   use Memoize
 
+  alias Memoize.Cache
+
   defmemo foo(x, y) when x == 0 do
     y
   end
@@ -46,16 +48,16 @@ defmodule MemoizeTest do
   test "invalidates cached values when call invalidate/{0-3}" do
     f = fn -> 10 end
 
-    Memoize.Cache.invalidate()
-    Memoize.Cache.get_or_run({:mod1, :fun1, [1]}, f)
-    Memoize.Cache.get_or_run({:mod1, :fun1, [2]}, f)
-    Memoize.Cache.get_or_run({:mod1, :fun2, [1]}, f)
-    Memoize.Cache.get_or_run({:mod2, :fun1, [1]}, f)
+    Cache.invalidate()
+    Cache.get_or_run(:mod1, :fun1, [1], f)
+    Cache.get_or_run(:mod1, :fun1, [2], f)
+    Cache.get_or_run(:mod1, :fun2, [1], f)
+    Cache.get_or_run(:mod2, :fun1, [1], f)
 
-    assert 1 == Memoize.invalidate(:mod1, :fun1, [1])
-    assert 1 == Memoize.invalidate(:mod1, :fun1)
-    assert 1 == Memoize.invalidate(:mod1)
-    assert 1 == Memoize.invalidate()
+    assert 1 == Cache.invalidate(:mod1, :fun1, [1])
+    assert 1 == Cache.invalidate(:mod1, :fun1)
+    assert 1 == Cache.invalidate(:mod1)
+    assert 1 == Cache.invalidate()
   end
 
   defmemo(nothing_do(x))


### PR DESCRIPTION
by setting config :memoize, caches: [ ModuleName ] in your config file
you can make use of this feature. it is backwards compatible with the
old way of doing things, and forked the default code leaving behind a
simple module that will ignore these changes as best it can.  I still
need to fix evection  but will get to that soon.